### PR TITLE
Support local files in proxyrules strategy via file:/// prefix

### DIFF
--- a/mockstack/constants.py
+++ b/mockstack/constants.py
@@ -7,6 +7,11 @@ ENV_PREFIX = "mockstack__"
 ENV_FILE = ".env"
 ENV_NESTED_DELIMITER = "__"
 
+# Template files are identified by a file:// URL prefix.
+PROXYRULES_FILE_TEMPLATE_PREFIX = "file:///"
+
+SENSITIVE_HEADERS = ["authorization", "cookie", "set-cookie"]
+
 
 class ProxyRulesRedirectVia(StrEnum):
     """The type of redirect to use for the proxy rules strategy.
@@ -20,6 +25,3 @@ class ProxyRulesRedirectVia(StrEnum):
     HTTP_TEMPORARY_REDIRECT = "http_307_temporary"
     HTTP_PERMANENT_REDIRECT = "http_301_permanent"
     REVERSE_PROXY = "reverse_proxy"
-
-
-SENSITIVE_HEADERS = ["authorization", "cookie", "set-cookie"]

--- a/mockstack/strategies/proxyrules.py
+++ b/mockstack/strategies/proxyrules.py
@@ -17,7 +17,7 @@ from jinja2 import Environment
 from starlette.datastructures import Headers
 
 from mockstack.config import Settings
-from mockstack.constants import ProxyRulesRedirectVia
+from mockstack.constants import PROXYRULES_FILE_TEMPLATE_PREFIX, ProxyRulesRedirectVia
 from mockstack.intent import looks_like_a_create
 from mockstack.strategies.base import BaseStrategy
 from mockstack.strategies.create_mixin import CreateMixin
@@ -95,9 +95,9 @@ class Rule:
         result = self._url_for(path)
 
         # Check if the replacement is a file template
-        if result.startswith("file:///"):
+        if result.startswith(PROXYRULES_FILE_TEMPLATE_PREFIX):
             # Extract the file path from the file:/// URL
-            file_path = result[7:]
+            file_path = result[len(PROXYRULES_FILE_TEMPLATE_PREFIX) - 1 :]
 
             # Create template context from request
             template_context = self._create_template_context(request)
@@ -276,7 +276,9 @@ class ProxyRulesStrategy(BaseStrategy, CreateMixin):
         except Exception as e:
             self.logger.error(f"Error rendering template {template_path}: {e}")
             return JSONResponse(
-                content={"error": "An internal error occurred while rendering the template."},
+                content={
+                    "error": "An internal error occurred while rendering the template."
+                },
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 

--- a/mockstack/strategies/proxyrules.py
+++ b/mockstack/strategies/proxyrules.py
@@ -2,7 +2,10 @@
 
 import logging
 import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from functools import cached_property
+from pathlib import Path
 from typing import Self
 from urllib.parse import urlparse
 
@@ -18,7 +21,40 @@ from mockstack.constants import ProxyRulesRedirectVia
 from mockstack.intent import looks_like_a_create
 from mockstack.strategies.base import BaseStrategy
 from mockstack.strategies.create_mixin import CreateMixin
-from mockstack.templating import templates_env_provider
+from mockstack.templating import (
+    templates_env_provider,
+    parse_template_name_segments_and_identifiers,
+)
+
+
+class RuleResult(ABC):
+    """Base class for rule application results."""
+
+    @abstractmethod
+    def get_result_type(self) -> str:
+        """Return the type of result."""
+        pass
+
+
+@dataclass
+class URLRuleResult(RuleResult):
+    """Result for URL-based rules."""
+
+    url: str
+
+    def get_result_type(self) -> str:
+        return "url"
+
+
+@dataclass
+class TemplateRuleResult(RuleResult):
+    """Result for template-based rules."""
+
+    template_path: str
+    template_context: dict
+
+    def get_result_type(self) -> str:
+        return "template"
 
 
 class Rule:
@@ -53,12 +89,43 @@ class Rule:
 
         return re.match(self.pattern, request.url.path) is not None
 
-    def apply(self, request: Request) -> str:
+    def apply(self, request: Request) -> RuleResult:
         """Apply the rule to the request."""
-        return self._url_for(request.url.path)
+        path = request.url.path
+        result = self._url_for(path)
+
+        # Check if the replacement is a file template
+        if result.startswith("file:///"):
+            # Extract the file path from the file:/// URL
+            file_path = result[7:]
+
+            # Create template context from request
+            template_context = self._create_template_context(request)
+
+            return TemplateRuleResult(
+                template_path=file_path,
+                template_context=template_context,
+            )
+        else:
+            # Regular URL replacement
+            return URLRuleResult(url=result)
 
     def _url_for(self, path: str) -> str:
         return re.sub(self.pattern, self.replacement, path)
+
+    def _create_template_context(self, request: Request) -> dict:
+        """Create template context from the request, using the same logic as templating.py."""
+        path = request.url.path
+        name_segments, identifiers = parse_template_name_segments_and_identifiers(
+            path, default_identifier_key="id"
+        )
+        return {
+            "query": dict(request.query_params),
+            "headers": dict(request.headers),
+            "path": request.url.path,
+            "method": request.method,
+            **identifiers,
+        }
 
 
 class ProxyRulesStrategy(BaseStrategy, CreateMixin):
@@ -112,46 +179,106 @@ class ProxyRulesStrategy(BaseStrategy, CreateMixin):
     async def apply(self, request: Request) -> Response:
         rule = self.rule_for(request)
         if rule is None:
-            self.logger.warning(
-                f"No rule found for request: {request.method} {request.url.path}"
+            return await self.handle_missing_rule(request)
+
+        result = rule.apply(request)
+        self.logger.info(f"[rule:{rule.name}] Result: {result}")
+
+        # Handle template results
+        if isinstance(result, TemplateRuleResult):
+            return await self.handle_template_result(request, rule, result)
+        elif isinstance(result, URLRuleResult):
+            return await self.handle_url_result(request, rule, result)
+        else:
+            raise ValueError(f"Unknown result type: {type(result)}")
+
+    async def handle_missing_rule(self, request: Request) -> Response:
+        """Handle a missing rule."""
+        self.logger.warning(
+            f"No rule found for request: {request.method} {request.url.path}"
+        )
+
+        if self.simulate_create_on_missing and looks_like_a_create(request):
+            self.logger.info(
+                f"Simulating resource creation for missing rule for {request.method} {request.url.path}"
+            )
+            return await self._create(
+                request,
+                env=self.env,
+                created_resource_metadata=self.created_resource_metadata,
+            )
+        else:
+            return JSONResponse(
+                content=self.missing_resource_fields,
+                status_code=status.HTTP_404_NOT_FOUND,
             )
 
-            if self.simulate_create_on_missing and looks_like_a_create(request):
-                self.logger.info(
-                    f"Simulating resource creation for missing rule for {request.method} {request.url.path}"
-                )
-                return await self._create(
-                    request,
-                    env=self.env,
-                    created_resource_metadata=self.created_resource_metadata,
-                )
-            else:
-                return JSONResponse(
-                    content=self.missing_resource_fields,
-                    status_code=status.HTTP_404_NOT_FOUND,
-                )
-
-        url = rule.apply(request)
-        self.logger.info(f"[rule:{rule.name}] Redirecting to: {url}")
-        self.update_opentelemetry(request, rule, url)
+    async def handle_url_result(
+        self, request: Request, rule: Rule, result: URLRuleResult
+    ) -> Response:
+        """Handle URL results by redirecting to the target URL."""
+        self.update_opentelemetry(request, rule, result.url)
 
         match self.redirect_via:
             case ProxyRulesRedirectVia.HTTP_TEMPORARY_REDIRECT:
                 return RedirectResponse(
-                    url=url, status_code=status.HTTP_307_TEMPORARY_REDIRECT
+                    url=result.url, status_code=status.HTTP_307_TEMPORARY_REDIRECT
                 )
 
             case ProxyRulesRedirectVia.HTTP_PERMANENT_REDIRECT:
                 return RedirectResponse(
-                    url=url, status_code=status.HTTP_301_MOVED_PERMANENTLY
+                    url=result.url, status_code=status.HTTP_301_MOVED_PERMANENTLY
                 )
 
             case ProxyRulesRedirectVia.REVERSE_PROXY:
-                response = await self.reverse_proxy(request, url)
+                response = await self.reverse_proxy(request, result.url)
                 return response
 
             case _:
                 raise ValueError(f"Invalid redirect via value: {self.redirect_via=}")
+
+    async def handle_template_result(
+        self, request: Request, rule: Rule, result: TemplateRuleResult
+    ) -> Response:
+        """Handle template results by rendering the template file."""
+        template_path = Path(result.template_path)
+
+        if not template_path.exists():
+            self.logger.error(f"Template file not found: {template_path}")
+            return JSONResponse(
+                content={"error": f"Template file not found: {template_path}"},
+                status_code=status.HTTP_404_NOT_FOUND,
+            )
+
+        try:
+            # Read the template file content
+            with open(template_path, "r") as f:
+                template_content = f.read()
+
+            # Create a template from the content
+            template = self.env.from_string(template_content)
+
+            # Render the template with context
+            rendered_content = template.render(**result.template_context)
+
+            # Determine content type based on file extension
+            content_type = self._get_content_type(template_path)
+
+            # Update opentelemetry with template info
+            self.update_opentelemetry_template(request, rule, result)
+
+            return Response(
+                content=rendered_content,
+                media_type=content_type,
+                status_code=status.HTTP_200_OK,
+            )
+
+        except Exception as e:
+            self.logger.error(f"Error rendering template {template_path}: {e}")
+            return JSONResponse(
+                content={"error": f"Template rendering error: {str(e)}"},
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
 
     async def reverse_proxy(self, request: Request, url: str) -> Response:
         """Reverse proxy the request to the target URL."""
@@ -186,6 +313,34 @@ class ProxyRulesStrategy(BaseStrategy, CreateMixin):
         _headers["host"] = urlparse(url).netloc
 
         return _headers
+
+    def _get_content_type(self, template_path: Path) -> str:
+        """Determine content type based on file extension."""
+        suffix = template_path.suffix.lower()
+        content_types = {
+            ".json": "application/json",
+            ".xml": "application/xml",
+            ".html": "text/html",
+            ".txt": "text/plain",
+            ".yaml": "application/x-yaml",
+            ".yml": "application/x-yaml",
+        }
+        return content_types.get(suffix, "text/plain")
+
+    def update_opentelemetry_template(
+        self, request: Request, rule: Rule, result: TemplateRuleResult
+    ) -> None:
+        """Update the opentelemetry span with template-specific details."""
+        span = request.state.span
+        if rule.name is not None:
+            span.set_attribute("mockstack.proxyrules.rule_name", rule.name)
+        if rule.method is not None:
+            span.set_attribute("mockstack.proxyrules.rule_method", rule.method)
+
+        span.set_attribute("mockstack.proxyrules.rule_pattern", rule.pattern)
+        span.set_attribute("mockstack.proxyrules.rule_replacement", rule.replacement)
+        span.set_attribute("mockstack.proxyrules.template_path", result.template_path)
+        span.set_attribute("mockstack.proxyrules.result_type", "template")
 
     def update_opentelemetry(self, request: Request, rule: Rule, url: str) -> None:
         """Update the opentelemetry span with the proxy rules rule details."""

--- a/mockstack/strategies/proxyrules.py
+++ b/mockstack/strategies/proxyrules.py
@@ -276,7 +276,7 @@ class ProxyRulesStrategy(BaseStrategy, CreateMixin):
         except Exception as e:
             self.logger.error(f"Error rendering template {template_path}: {e}")
             return JSONResponse(
-                content={"error": f"Template rendering error: {str(e)}"},
+                content={"error": "An internal error occurred while rendering the template."},
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 

--- a/mockstack/tests/strategies/test_proxyrules.py
+++ b/mockstack/tests/strategies/test_proxyrules.py
@@ -9,7 +9,12 @@ from fastapi.responses import RedirectResponse
 from starlette.datastructures import Headers
 
 from mockstack.constants import ProxyRulesRedirectVia
-from mockstack.strategies.proxyrules import ProxyRulesStrategy, Rule
+from mockstack.strategies.proxyrules import (
+    ProxyRulesStrategy,
+    Rule,
+    URLRuleResult,
+    TemplateRuleResult,
+)
 
 
 def test_rule_from_dict():
@@ -113,9 +118,35 @@ def test_rule_apply(pattern, replacement, path, expected_url):
             "headers": [],
         }
     )
-    url = rule.apply(request)
-    assert isinstance(url, str)
-    assert url == expected_url
+    result = rule.apply(request)
+    assert isinstance(result, URLRuleResult)
+    assert result.get_result_type() == "url"
+    assert result.url == expected_url
+
+
+def test_rule_apply_template():
+    """Test the rule application logic for template files."""
+    rule = Rule(
+        pattern=r"/api/v1/projects/(\d+)",
+        replacement=r"file:///path/to/template.json",
+    )
+    request = Request(
+        scope={
+            "type": "http",
+            "method": "GET",
+            "path": "/api/v1/projects/1234",
+            "query_string": b"",
+            "headers": [],
+        }
+    )
+    result = rule.apply(request)
+    assert isinstance(result, TemplateRuleResult)
+    assert result.get_result_type() == "template"
+    assert result.template_path == "/path/to/template.json"
+    assert result.template_context is not None
+    # The context should contain the extracted project ID from the path
+    assert "projects" in result.template_context
+    assert result.template_context["projects"] == "1234"
 
 
 def test_proxy_rules_strategy_load_rules(settings):
@@ -196,6 +227,60 @@ async def test_proxy_rules_strategy_apply_no_match(settings, span):
     request.state.span = span
     response = await strategy.apply(request)
     assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_proxy_rules_strategy_apply_template(settings, span, tmp_path):
+    """Test applying strategy with template rendering."""
+    # Create a template file
+    template_file = tmp_path / "template.json"
+    template_file.write_text(
+        '{"projects": "{{ projects }}", "name": "Project {{ projects }}"}'
+    )
+
+    # Create a rule that points to the template file
+    rule_data = {
+        "pattern": r"/api/v1/projects/(\d+)",
+        "replacement": f"file:///{template_file}",
+        "name": "test_template_rule",
+    }
+
+    # Mock the rule_for method to return our test rule
+    strategy = ProxyRulesStrategy(settings)
+    test_rule = Rule.from_dict(rule_data)
+
+    with patch.object(strategy, "rule_for", return_value=test_rule):
+        request = Request(
+            scope={
+                "type": "http",
+                "method": "GET",
+                "path": "/api/v1/projects/1234",
+                "query_string": b"",
+                "headers": [],
+            }
+        )
+        request.state.span = span
+        response = await strategy.apply(request)
+
+        assert response.status_code == 200
+        assert response.media_type == "application/json"
+        assert response.body.decode() == '{"projects": "1234", "name": "Project 1234"}'
+
+
+def test_proxy_rules_strategy_get_content_type(settings):
+    """Test content type detection based on file extension."""
+    strategy = ProxyRulesStrategy(settings)
+
+    from pathlib import Path
+
+    # Test various file extensions
+    assert strategy._get_content_type(Path("file.json")) == "application/json"
+    assert strategy._get_content_type(Path("file.xml")) == "application/xml"
+    assert strategy._get_content_type(Path("file.html")) == "text/html"
+    assert strategy._get_content_type(Path("file.txt")) == "text/plain"
+    assert strategy._get_content_type(Path("file.yaml")) == "application/x-yaml"
+    assert strategy._get_content_type(Path("file.yml")) == "application/x-yaml"
+    assert strategy._get_content_type(Path("file.unknown")) == "text/plain"
 
 
 @pytest.mark.asyncio

--- a/mockstack/tests/strategies/test_proxyrules.py
+++ b/mockstack/tests/strategies/test_proxyrules.py
@@ -1,5 +1,6 @@
 """Unit tests for the proxyrules module."""
 
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -270,8 +271,6 @@ async def test_proxy_rules_strategy_apply_template(settings, span, tmp_path):
 def test_proxy_rules_strategy_get_content_type(settings):
     """Test content type detection based on file extension."""
     strategy = ProxyRulesStrategy(settings)
-
-    from pathlib import Path
 
     # Test various file extensions
     assert strategy._get_content_type(Path("file.json")) == "application/json"


### PR DESCRIPTION
- Support local file paths in the proxyrules strategy and rules file format via the `file:///` prefix
- Update unit-testing for new functionality