### PR TITLE
fix content-length when handling compressed content

### DIFF
--- a/mockstack/tests/strategies/test_proxyrules.py
+++ b/mockstack/tests/strategies/test_proxyrules.py
@@ -359,15 +359,18 @@ async def test_proxy_rules_strategy_reverse_proxy(settings_reverse_proxy, span):
 
         mock_client.send.assert_called_once()
 
-    def test_maybe_update_response_headers_updates_content_encoding():
-        """Test maybe_update_response_headers updates content-encoding."""
-        headers = Headers(
-            {"content-encoding": "gzip", "content-type": "application/json"}
-        )
-        request_headers = Headers({"accept-encoding": "gzip"})
 
-        updated_headers = maybe_update_response_headers(headers, request_headers)
+def test_maybe_update_response_headers_updates_content_encoding():
+    """Test maybe_update_response_headers updates content-encoding."""
+    response_headers = httpx.Headers(
+        {"content-encoding": "gzip", "content-type": "application/json"}
+    )
 
-        assert updated_headers["content-encoding"] == "identity"
-        assert updated_headers["content-type"] == "application/json"
-        assert updated_headers["accept-encoding"] == "gzip"
+    updated_headers = maybe_update_response_headers(
+        response_headers=response_headers,
+        content_length=100,
+    )
+
+    assert updated_headers["content-encoding"] == "identity"
+    assert updated_headers["content-type"] == "application/json"
+    assert updated_headers["content-length"] == "100"


### PR DESCRIPTION
- fix content-length when handling compressed content since it is returned uncompressed to the client